### PR TITLE
Show error message if we chan't check latest version.

### DIFF
--- a/classes/DomainMOD/System.php
+++ b/classes/DomainMOD/System.php
@@ -89,6 +89,16 @@ class System
 
     public function getLiveVersion()
     {
+        // Need openssl support to file_get_contents https urls.
+        if( !extension_loaded( 'openssl' ) ) {
+            exit( 'Please enable php openssl support for domainmod version checking.' );
+        }
+
+        // Need allow_url_fopen support to file_get_contents urls.
+        if( !ini_get( 'allow_url_fopen' ) ) {
+            exit( 'Please turn on allow_url_fopen support for domainmod version checking.');
+        }
+        
         $version_file = 'https://raw.githubusercontent.com/domainmod/domainmod/master/version.txt';
         $context = stream_context_create(array('https' => array('header' => 'Connection: close\r\n')));
         $version_fgc = file_get_contents($version_file, false, $context);


### PR DESCRIPTION
If extension openssl or allow_url_fopen are not enabled, domainmod will silently fail to check the latest version on github. I don't like messages filling up the php error log even if it's just a warning. It means something is wrong.